### PR TITLE
Handle an empty topic string

### DIFF
--- a/src/rqt_robot_steering/robot_steering.py
+++ b/src/rqt_robot_steering/robot_steering.py
@@ -141,6 +141,8 @@ class RobotSteering(Plugin):
     def _on_topic_changed(self, topic):
         topic = str(topic)
         self._unregister_publisher()
+        if topic == "":
+            return
         try:
             self._publisher = rospy.Publisher(topic, Twist, queue_size=10)
         except TypeError:

--- a/src/rqt_robot_steering/robot_steering.py
+++ b/src/rqt_robot_steering/robot_steering.py
@@ -141,7 +141,7 @@ class RobotSteering(Plugin):
     def _on_topic_changed(self, topic):
         topic = str(topic)
         self._unregister_publisher()
-        if topic == "":
+        if topic == '':
             return
         try:
             self._publisher = rospy.Publisher(topic, Twist, queue_size=10)


### PR DESCRIPTION
The call to rospy.publisher will throw an exception otherwise, but unregistering then doing nothing seems fine as the user may not want to publish anything or has just deleted the old contents and is about to type in something new.