### PR TITLE
feat: always send zero twist message on stop button pressed

### DIFF
--- a/src/rqt_robot_steering/robot_steering.py
+++ b/src/rqt_robot_steering/robot_steering.py
@@ -149,8 +149,14 @@ class RobotSteering(Plugin):
             self._publisher = rospy.Publisher(topic, Twist)
 
     def _on_stop_pressed(self):
-        self._widget.x_linear_slider.setValue(0)
-        self._widget.z_angular_slider.setValue(0)
+        # If the current value of sliders is zero directly send stop twist msg
+        if self._widget.x_linear_slider.value() is 0 and \
+                self._widget.z_angular_slider.value() is 0:
+            self.zero_cmd_sent = False
+            self._on_parameter_changed()
+        else:
+            self._widget.x_linear_slider.setValue(0)
+            self._widget.z_angular_slider.setValue(0)
 
     def _on_x_linear_slider_changed(self):
         self._widget.current_x_linear_label.setText('%0.2f m/s' % (self._widget.x_linear_slider.value() / RobotSteering.slider_factor))


### PR DESCRIPTION
In many situations, the non-zero velocity command was sent by some other nodes while the value of sliders is zero. In this case, clicking on stop button wouldn't do anything since the `on_parameter_changed()` wouldn't trigger.
This PR, adds a condition to check this special case so that it will explicitly trigger the `_on_parameter_changed()` slot and also sets the `zero_cmd_sent` to `False` to make the repetitive usage of stop button possible.