### PR TITLE
Use console_script entrypoint

### DIFF
--- a/scripts/rqt_robot_steering
+++ b/scripts/rqt_robot_steering
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-import sys
-
-from rqt_gui.main import Main
-
-main = Main()
-sys.exit(main.main(sys.argv, standalone='rqt_robot_steering.robot_steering.RobotSteering'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/rqt_robot_steering
+[install]
+install_scripts=$base/lib/rqt_robot_steering

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
         ('share/' + package_name + '/resource', ['resource/RobotSteering.ui']),
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name, ['plugin.xml']),
-        ('lib/' + package_name, ['scripts/rqt_robot_steering'])
     ],
     install_requires=['setuptools'],
     zip_safe=True,
@@ -30,5 +29,9 @@ setup(
         'rqt_robot_steering provides a GUI plugin for steering a robot using Twist messages.'
     ),
     license='BSD',
-    scripts=['scripts/rqt_robot_steering'],
+    entry_points={
+        'console_scripts': [
+            'rqt_robot_steering = ' + package_name + '.main:main',
+            ],
+    },
 )

--- a/src/rqt_robot_steering/main.py
+++ b/src/rqt_robot_steering/main.py
@@ -1,0 +1,12 @@
+import sys
+
+from rqt_gui.main import Main
+
+
+def main():
+    main = Main()
+    sys.exit(main.main(sys.argv, standalone='rqt_robot_steering.robot_steering.RobotSteering'))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This resolves not being able to run rqt_robot_steering in ros2 on windows. The same changes were made to most other rqt plugins: https://github.com/ros-visualization/rqt_console/issues/20

tested on Windows 11 on ROS2 Rolling.