### PR TITLE
make min/max values int

### DIFF
--- a/src/rqt_robot_steering/robot_steering.py
+++ b/src/rqt_robot_steering/robot_steering.py
@@ -229,19 +229,19 @@ class RobotSteering(Plugin):
 
     def _on_max_x_linear_changed(self, value):
         self._widget.x_linear_slider.setMaximum(
-            value * RobotSteering.slider_factor)
+            int(value * RobotSteering.slider_factor))
 
     def _on_min_x_linear_changed(self, value):
         self._widget.x_linear_slider.setMinimum(
-            value * RobotSteering.slider_factor)
+            int(value * RobotSteering.slider_factor))
 
     def _on_max_z_angular_changed(self, value):
         self._widget.z_angular_slider.setMaximum(
-            value * RobotSteering.slider_factor)
+            int(value * RobotSteering.slider_factor))
 
     def _on_min_z_angular_changed(self, value):
         self._widget.z_angular_slider.setMinimum(
-            value * RobotSteering.slider_factor)
+            int(value * RobotSteering.slider_factor))
 
     def _on_strong_increase_x_linear_pressed(self):
         self._widget.x_linear_slider.setValue(


### PR DESCRIPTION
Newer python (3.10) errors with 

```
TypeError: setMaximum(self, int): argument 1 has unexpected type 'float'
```