### PR TITLE
Add rudamentary message type selection

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <author>Dirk Thomas</author>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/resource/RobotSteering.ui
+++ b/resource/RobotSteering.ui
@@ -15,6 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0">
    <item>
+    <widget class="QComboBox" name="msgtype_combo_box">
+     <property name="toolTip">
+      <string>Message type selection</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLineEdit" name="topic_line_edit">


### PR DESCRIPTION
Since ros2_control now uses TwistStamped by default for DiffDriveControllers I added the option to use both message types with a dropdown. The code quality could surely be improved if this is useful for other people as well