### PR TITLE
Publish TwistStamped message optionally

### DIFF
--- a/resource/RobotSteering.ui
+++ b/resource/RobotSteering.ui
@@ -27,6 +27,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="stamped_check_box">
+       <property name="text">
+        <string>stamped</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="stop_push_button">
        <property name="toolTip">
         <string>Reset velocities to zero</string>


### PR DESCRIPTION
We started recently to drop the Twist messages without timestamp from ros2_control, see https://github.com/ros-controls/ros2_controllers/pull/812.

This makes changes to this plugin necessary. 

I saw the PR #16 from @ahcorde but just adding `_stamped`to the topic name doesn't work without additional topic name remapping. 

Thererfore, I propose a different approach: I added a checkbox `stamped`, and the plugin only selects the stamped or non-stamped topic depending on the checkbox's state.

![image](https://github.com/ros-visualization/rqt_robot_steering/assets/3367244/f286793a-e18f-4d53-ac86-9dbb38326b37)
