### PR TITLE
Fix none check of publisher to publish twist message

### DIFF
--- a/src/rqt_robot_steering/robot_steering.py
+++ b/src/rqt_robot_steering/robot_steering.py
@@ -302,6 +302,12 @@ class RobotSteering(Plugin):
             self._widget.z_angular_slider.value() / RobotSteering.slider_factor)
 
     def _send_twist(self, x_linear, z_angular):
+        def _publish_twist():
+            if self._use_stamped:
+                self._publisher_stamped.publish(twist_stamped)
+            else:
+                self._publisher.publish(twist)
+
         if self._publisher is None and self._publisher_stamped is None:
             return
 
@@ -322,13 +328,10 @@ class RobotSteering(Plugin):
         if x_linear == 0.0 and z_angular == 0.0:
             if not self.zero_cmd_sent:
                 self.zero_cmd_sent = True
+                _publish_twist()
         else:
             self.zero_cmd_sent = False
-
-        if self._use_stamped:
-            self._publisher_stamped.publish(twist_stamped)
-        else:
-            self._publisher.publish(twist)
+            _publish_twist()
 
     def _unregister_publisher(self):
         if self._publisher is not None:

--- a/src/rqt_robot_steering/robot_steering.py
+++ b/src/rqt_robot_steering/robot_steering.py
@@ -302,7 +302,7 @@ class RobotSteering(Plugin):
             self._widget.z_angular_slider.value() / RobotSteering.slider_factor)
 
     def _send_twist(self, x_linear, z_angular):
-        if self._publisher_stamped is None and self._publisher_stamped is None:
+        if self._publisher is None and self._publisher_stamped is None:
             return
 
         twist = Twist()


### PR DESCRIPTION
Since this PR (https://github.com/ros-visualization/rqt_robot_steering/pull/18), this tool has been able to publish twist stamps.

However, that PR causes
- preventing publishing twist data
- publish data every time, even if zero speed
  -  the original was sent only once if zero speed


This PR fixes these.

For the second point, sorry if that was your intention @christophfroehlich 